### PR TITLE
Release v0.2.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,5 @@
 ^docs$
 ^pkgdown$
 ^\.travis\.yml$
+^codecov\.yml$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,1 @@
+R/gallery_site_generator.R

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: R
 cache: packages
 
+after_success:
+  - Rscript -e 'covr::codecov()'
+
 before_cache: Rscript -e 'install.packages("pkgdown")'
 before_deploy: Rscript -e 'pkgdown::build_site()'
 deploy:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R:
            email = "riccardo.porreca@mirai-solutions.com")
 Description: Provide an R Markdown website generator to build a website 
     including a gallery of (embedded) pages created in a dynamic way based on
-    metadata in JSON format.
+    metadata in JSON or YAML format.
 License: GPL-3
 URL: https://github.com/riccardoporreca/rmdgallery
 BugReports: https://github.com/riccardoporreca/rmdgallery/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     rmarkdown,
     yaml
 Suggests: 
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    covr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     htmltools,
     jsonlite,
     knitr,
-    rmarkdown
+    rmarkdown,
+    yaml
 Suggests: 
     testthat (>= 2.1.0)
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Metadata in YAML format are now also supported (#2).
 - Custom _page types_ are now supported as an alternative to the `template` field of the metadata. Page types are defined and mapped to actual templates in the `gallery` site configuration, using new fields `type_field` and `type_template` (#4).
+- Default values for unspecified fields in the metadata can now be defined using the new `defaults` field in the `gallery` site configuration (#3).
 
 # rmdgallery 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rmdgallery (development version)
+
 # rmdgallery 0.1.0
 
 ## First versioned release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rmdgallery (development version)
 
 - Metadata in YAML format are now also supported (#2).
+- Custom _page types_ are now supported as an alternative to the `template` field of the metadata. Page types are defined and mapped to actual templates in the `gallery` site configuration, using new fields `type_field` and `type_template` (#4).
 
 # rmdgallery 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- Metadata in YAML format are now also supported (#2).
+
 # rmdgallery 0.1.0
 
 ## First versioned release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,15 @@
-# rmdgallery (development version)
+# rmdgallery 0.2.0
+
+## New features
 
 - Metadata in YAML format are now also supported (#2).
 - Custom _page types_ are now supported as an alternative to the `template` field of the metadata. Page types are defined and mapped to actual templates in the `gallery` site configuration, using new fields `type_field` and `type_template` (#4).
 - Default values for unspecified fields in the metadata can now be defined using the new `defaults` field in the `gallery` site configuration (#3).
+
+## Maintenance
+
+- Updated package README to cover new features and point to branch `develop` for using the development version.
+- Extended test coverage for new as well as existing utilities.
 
 # rmdgallery 0.1.0
 

--- a/R/config.R
+++ b/R/config.R
@@ -7,8 +7,9 @@
 #' @return The function returns the contents of `_site.yml` as an \R list, with
 #'   an additional element `$gallery$meta`, a list containing the metadata of
 #'   the pages to be generated, as read from the `.json`, `.yml` and `yaml`
-#'   files, where `$gallery$type_field` and `gallery$type_template` have been
-#'   already used to lookup the actual `template`.
+#'   files, where `$gallery$type_field` and `gallery$type_template` (if present)
+#'   have been already used to lookup the actual `template`. In addition,
+#'   default field values specified as `gallery$defaults` are also applied.
 #'
 #' @export
 gallery_site_config <- function(input = ".") {
@@ -19,6 +20,7 @@ gallery_site_config <- function(input = ".") {
     meta_files <- site_meta_files(file.path(input, meta_dir))
     meta <- read_meta(meta_files, single_meta)
     meta <- with_type_template(meta, config$gallery)
+    meta <- with_defaults(meta, config$gallery)
     check_missing_template(meta)
     config$gallery$meta <- meta
   }
@@ -61,6 +63,16 @@ get_type_template <- function(type, type_templates) {
   )
 }
 
+with_defaults <- function(meta, gallery_config) {
+  default_fields <- names(gallery_config$defaults)
+  for (field in default_fields) {
+    values <- get_meta_field(meta, field)
+    values <- values %|NA|% gallery_config$defaults[[field]]
+    meta <- set_meta_field(meta, field, values)
+  }
+  meta
+}
+
 check_missing_template <- function(meta) {
   miss_template <- is.na(get_meta_field(meta, "template"))
   if (any(miss_template)) {
@@ -71,3 +83,4 @@ check_missing_template <- function(meta) {
   }
   invisible(meta)
 }
+

--- a/R/config.R
+++ b/R/config.R
@@ -6,7 +6,8 @@
 #'
 #' @return The function returns the contents of `_site.yml` as an \R list, with
 #'   an additional element `$gallery$meta`, a list containing the metadata of
-#'   the pages to be generated, as read from the `.json` file.
+#'   the pages to be generated, as read from the `.json`, `.yml` and `yaml`
+#'   files.
 #'
 #' @export
 gallery_site_config <- function(input = ".") {

--- a/R/config.R
+++ b/R/config.R
@@ -7,7 +7,8 @@
 #' @return The function returns the contents of `_site.yml` as an \R list, with
 #'   an additional element `$gallery$meta`, a list containing the metadata of
 #'   the pages to be generated, as read from the `.json`, `.yml` and `yaml`
-#'   files.
+#'   files, where `$gallery$type_field` and `gallery$type_template` have been
+#'   already used to lookup the actual `template`.
 #'
 #' @export
 gallery_site_config <- function(input = ".") {
@@ -16,7 +17,57 @@ gallery_site_config <- function(input = ".") {
     meta_dir <- config$gallery$meta_dir %||% "meta"
     single_meta <- config$gallery$single_meta %||% FALSE
     meta_files <- site_meta_files(file.path(input, meta_dir))
-    config$gallery$meta <- read_meta(meta_files, single_meta)
+    meta <- read_meta(meta_files, single_meta)
+    meta <- with_type_template(meta, config$gallery)
+    check_missing_template(meta)
+    config$gallery$meta <- meta
   }
   config
+}
+
+with_type_template <- function(meta, gallery_config)(
+  if (!is.null(gallery_config$type_field)) {
+    meta <- assign_type_template(
+      meta,
+      gallery_config$type_field,
+      gallery_config$type_template
+    )
+  }
+)
+
+assign_type_template <- function(meta, type_field, type_templates) {
+  template <- get_meta_field(meta, "template")
+  type <- get_meta_field(meta, type_field)
+  with_type <- is.na(template) & !is.na(type)
+  template_from_type <- get_type_template(type[with_type], type_templates)
+  miss_template <- is.na(template_from_type )
+  if (any(miss_template)) {
+    stop(
+      "Missing template specification for custom type(s) ",
+      toQuotedString(unique(type[with_type][miss_template]))
+    )
+  }
+  meta[with_type] <- set_meta_field(
+    meta[with_type],
+    "template", template_from_type
+  )
+  meta
+}
+
+get_type_template <- function(type, type_templates) {
+  vapply(
+    type, FUN.VALUE = NA_character_,
+    function(x) type_templates[[x]] %||% NA_character_
+  )
+}
+
+check_missing_template <- function(meta) {
+  miss_template <- is.na(get_meta_field(meta, "template"))
+  if (any(miss_template)) {
+    stop(
+      "Missing template specification for: ",
+      toQuotedString(names(meta)[miss_template])
+    )
+  }
+  invisible(meta)
 }

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -56,7 +56,7 @@ gallery_site <- function(input, ...) {
       if (any(duplicated)) {
         stop(
           "Found duplicate navbar menu entries: ",
-          toString(sQuote(gallery_entry[has_entry][duplicated])))
+          toQuotedString(gallery_entry[has_entry][duplicated]))
       }
       gallery_navbar[[1L]][[1]]$menu <- mapply(
         SIMPLIFY = FALSE, USE.NAMES = FALSE,

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -5,7 +5,7 @@
 #'
 #' Define a custom website generator to be used with [rmarkdown::render_site()].
 #' This generates a simple R Markdown website including a gallery of pages with
-#' embedded content, based on metadata in JSON format and custom site
+#' embedded content, based on metadata in JSON or YAML format and custom site
 #' configuration options.
 #'
 #' @inheritParams rmarkdown::default_site_generator

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -118,7 +118,7 @@ gallery_site <- function(input, ...) {
       if (tools::file_ext(x) == "meta") {
         name <- tools::file_path_sans_ext(x)
         meta <- config$gallery$meta[[name]]
-        if (!quiet) message("\nMetadata from: ", meta$source)
+        if (!quiet) message("\nMetadata from: ", meta$.meta_file)
         # gallery config:
         meta$gallery_config <- if (is.null(config$gallery)) list() else config$gallery
         output_file <- file.path(input, file_with_ext(name, "html"))

--- a/R/meta.R
+++ b/R/meta.R
@@ -1,13 +1,26 @@
 
 site_meta_files <- function(path) {
-  list.files(path, "[.]json$", full.names = TRUE)
+  list.files(path, "[.](json|ya?ml)$", full.names = TRUE)
+}
+
+read_meta_file <- function(file, ...) {
+  ext <- tools::file_ext(basename(file))
+  reader <- list(
+    json = jsonlite::read_json,
+    yaml = yaml::read_yaml,
+    yml = yaml::read_yaml
+  )[[ext]]
+  if (is.null(ext)) {
+    stop("Extension .", ext, " not supported.")
+  }
+  reader(file, ...)
 }
 
 read_meta <- function(files, single = FALSE) {
-  do.call(
+  meta <- do.call(
     c,
     lapply(files, function(file) {
-      meta <- jsonlite::read_json(file)
+      meta <- read_meta_file(file)
       if (isTRUE(single)) {
         meta <- list(meta)
         names(meta) <- tools::file_path_sans_ext(basename(file))
@@ -19,4 +32,12 @@ read_meta <- function(files, single = FALSE) {
       meta
     })
   )
+  dup_meta <- duplicated(names(meta))
+  if (any(dup_meta)) {
+    stop(
+      "Duplicated page names found in the metadata: ",
+      toQuotedString(unique(names(meta)[dup_meta]))
+    )
+  }
+  meta
 }

--- a/R/meta.R
+++ b/R/meta.R
@@ -25,10 +25,7 @@ read_meta <- function(files, single = FALSE) {
         meta <- list(meta)
         names(meta) <- tools::file_path_sans_ext(basename(file))
       }
-      meta <- lapply(meta, function(x) {
-        x$source <- basename(file)
-        x
-      })
+      meta <- lapply(meta, c, list(.meta_file = basename(file)))
       meta
     })
   )

--- a/R/meta.R
+++ b/R/meta.R
@@ -38,3 +38,20 @@ read_meta <- function(files, single = FALSE) {
   }
   meta
 }
+
+get_meta_field <- function(meta, field, missing_value = NA_character_) {
+  vapply(
+    meta, FUN.VALUE = missing_value,
+    function(x) x[[field]] %||% missing_value
+  )
+}
+
+set_meta_field <- function(meta, field, value) {
+  Map(
+    function(x, value) {
+      x[[field]] <- if (!is.na(value)) value
+      x
+    },
+    meta, value
+  )
+}

--- a/R/templates.R
+++ b/R/templates.R
@@ -105,7 +105,7 @@ find_template <- function(template, paths = character(0)) {
     }
   }
   if (is.null(template_file)) {
-    stop("No template found for ", sQuote(template), " in ", toString(sQuote(paths)))
+    stop("No template found for ", toQuotedString(template), " in ", toQuotedString(paths))
   }
   template_file
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -3,6 +3,11 @@
   if (is.null(x)) value_if_null else x
 }
 
+`%|NA|%` <- function(x, value_if_na) {
+  x[is.na(x)] <- value_if_na
+  x
+}
+
 # define a list of utilities to be made available when rendering
 render_time_utils <- list(
   `%||%` = `%||%`

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,3 +7,7 @@
 render_time_utils <- list(
   `%||%` = `%||%`
 )
+
+toQuotedString <- function(x) {
+  toString(sQuote(x, q = FALSE))
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <!-- badges: start -->
 [![R build status](https://github.com/riccardoporreca/rmdgallery/workflows/R-CMD-check/badge.svg)](https://github.com/riccardoporreca/rmdgallery/actions)
 [![Travis build status](https://travis-ci.com/riccardoporreca/rmdgallery.svg?branch=master)](https://travis-ci.com/riccardoporreca/rmdgallery)
+[![Codecov test coverage](https://codecov.io/gh/riccardoporreca/rmdgallery/branch/master/graph/badge.svg)](https://codecov.io/gh/riccardoporreca/rmdgallery?branch=master)
 <!-- badges: end -->
 
 The goal of **rmdgallery** is to provide an R Markdown [site generator](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#custom-site-generators) that supports the inclusion of a gallery of (embedded) pages created in a dynamic way based on metadata in JSON or YAML format.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An example of using **rmdgallery** can can be found in the [rmd-gallery-example]
 
 ## Installation
 
-You can install the **rmdgallery** package from GitHub with:
+You can install the [latest released](https://github.com/riccardoporreca/rmdgallery/releases/latest) version of **rmdgallery** package from GitHub with:
 
 ``` r
 remotes::install_github("riccardoporreca/rmdgallery")
@@ -28,6 +28,12 @@ Remotes:
   riccardoporreca/rmdgallery
 ```
 See e.g. [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example/blob/master/DESCRIPTION).
+
+If you want to use the development version of the package, it is available from the [`develop`](https://github.com/riccardoporreca/rmdgallery/tree/develop) branch `riccardoporreca/rmdgallery@develop`, which can be used with `remotes::install_github()`
+``` r
+remotes::install_github("riccardoporreca/rmdgallery@develop")
+```
+or in the `Remotes:` field of the `DESCRIPTION` file.
 
 ## Using rmdgallery
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This approach can be particularly useful for galleries with user-contributed pag
 
 ### Configuration and customization
 
-Configuration and customization of the website specific to `rmdgallery::gallery_site_generator` are defined by adding a `gallery:` field to the standard `_site.yml` configuration file. The following examples describe the available options:
+Configuration and customization of the website specific to `rmdgallery::gallery_site_generator` are defined by adding a `gallery:` field to the standard `_site.yml` configuration file. The following example describes the available options:
 
 ``` yaml
 name: "my-website"
@@ -115,6 +115,8 @@ gallery:
   type_template:
     type_1: embed-url
     type_2: embed-html
+  defaults:
+    template: embed-url
   navbar:
     left:
       - text: "Gallery"
@@ -133,6 +135,7 @@ gallery:
 - `single_meta:` Optional `true` or `false` defining whether the files define metadata for individual pages, in which case e.g. a file `foo.json` would contain only the metadata for the `foo.html` page. Defaults to `false` if not specified.
 - `template_dir:` Optional location of additional custom templates.
 - `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
+- `defaults:` Optional list of default values for unspecified metadata fields.
 - `navbar:` The gallery navigation menu to be included in the standard `navbar:` of `_site.yml`. The menu is populated with the `menu_entry` of each page from the metadata. Can be omitted if no such menu should be included.
 - `include_before:`, `include_after:` Custom content to be included before and after the main `content`. Both are included for each page and may be defined in terms of fields from the metadata via using `{{...}}`. Such placeholders are then processed using `glue::glue_data(meta)`, where `meta` is the list of metadata for a given page. This allows to use simple string replacements of raw HTML code (like in `include_before:` in the example) or R expression constructing HTML elements via [**htmltools**](https://cran.r-project.org/package=htmltools) (like in `include_after:`).
 

--- a/README.md
+++ b/README.md
@@ -46,22 +46,19 @@ Below we describe how the **_metadata_** for multiple pages are defined and used
 
 At the core of **rmdgallery** are R Markdown templates for the pages to be included in the website, containing placeholders for metadata. The details behind how templates define and make use of metadata are covered in section ['Custom templates'](#custom-templates) below.
 
-The specific metadata of each individual page are defined in JSON (`.json`) or YAML (`.yml`, `.yaml`) file(s) in the `meta` directory of the website project. For example, the following JSON (or an analogous YAML)
-``` json
-{
-  "foo": {
-    "title": "Embed raw html content",
-    "menu_entry": "HTML example",
-    "template": "embed-html",
-    "content": "<h3>Hello Rmd Gallery</h3>"
-  },
-  "bar": {
-    "title": "Embed content from an external URL",
-    "menu_entry": "URL example",
-    "template": "embed-url",
-    "content": "https://example.com"
-  }
-}
+The specific metadata of each individual page are defined in JSON (`.json`) or YAML (`.yml`, `.yaml`) file(s) in the `meta` directory of the website project. For example, the following YAML (or an analogous JSON)
+``` yaml
+foo: 
+  title: Embed raw html content
+  menu_entry: HTML example
+  template: embed-html
+  content: <h3>Hello Rmd Gallery</h3>
+
+bar: 
+  title: Embed content from an external URL
+  menu_entry: URL example
+  template: embed-url
+  content: https://example.com
 ```
 defines the metadata for pages rendered as `foo.html` and `bar.html` with the given page `title`, also adding the specified `menu_entry` to the [site navigation bar](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site-navigation).
 
@@ -71,14 +68,16 @@ The predefined templates provided by **rmdgallery** are described next.
 
 #### `"template": "embed-url"`
 
-Embed a page given its URL, using `<ifame src={{content}}>`, where `{{content}}` is the embedded page URL specified as `content` in the metadata. In addition, an optional `css` field in the metadata allows to fine-tune the CSS style of the `<iframe>`. In particular, `height` can be useful for defining the height (in valid CSS units) of the embedded non-responsive content, as in the following example:
+Embed a page given its URL, using `<ifame src={{content}}>`, where `{{content}}` is the embedded page URL specified as `content` in the metadata. In addition, an optional `css` field in the metadata allows to fine-tune the CSS style of the `<iframe>`. In particular, `height` can be useful for defining the height (in valid CSS units) of the embedded non-responsive content, as in the following JSON example:
 ``` json
 {
-  "title": "My Title",
-  "template": "embed-url",
-  "content": "https://bookdown.org/yihui/rmarkdown",
-  "css": {
-    "height": "80vh"
+  "foo": {
+    "title": "My Title",
+    "template": "embed-url",
+    "content": "https://bookdown.org/yihui/rmarkdown",
+    "css": {
+      "height": "80vh"
+    }
   }
 }
 ```
@@ -91,6 +90,11 @@ Embed the HTML code defined in the `content` field of the metadata. This can be 
 
 Embed based on JavaScript, using `<script src={{content}}>`, where `{{content}}` is the URL of a `.js` script. This is a special case of `embed-html`, useful e.g. for embedding a GitHub [gist](https://help.github.com/en/github/writing-on-github/editing-and-sharing-content-with-gists).
 
+#### Page types
+
+An alternative way to defining a `template` field in the metadata is to use a custom field (e.g., `my_type`) defining the page _type_, and associate its possible custom values to actual templates. This is achieved by defining the `type_field` (e.g., `type_field: my_type`) and the `type_template` list of value-to-template maps (e.g., `type_1: embed-url`) in the `gallery` configuration (see below), so that metadata specifying field `my_type: type_1` (e.g. in YAML format) would be rendered using the `embed-url` template.
+
+This approach can be particularly useful for galleries with user-contributed pages and metadata, where context-specific types (e.g., `type: shiny`) would be more informative than the rather technical `template`.
 
 ### Configuration and customization
 
@@ -107,6 +111,10 @@ gallery:
   meta_dir: "meta"
   single_meta: false
   template_dir: "path/to/cutom/templates"
+  type_field: my_type
+  type_template:
+    type_1: embed-url
+    type_2: embed-html
   navbar:
     left:
       - text: "Gallery"
@@ -124,10 +132,11 @@ gallery:
 - `meta_dir:` Optional name of the directory containing `.json`, `.yml` and `.yaml` metadata files. Defaults to `meta` if not specified.
 - `single_meta:` Optional `true` or `false` defining whether the files define metadata for individual pages, in which case e.g. a file `foo.json` would contain only the metadata for the `foo.html` page. Defaults to `false` if not specified.
 - `template_dir:` Optional location of additional custom templates.
+- `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
 - `navbar:` The gallery navigation menu to be included in the standard `navbar:` of `_site.yml`. The menu is populated with the `menu_entry` of each page from the metadata. Can be omitted if no such menu should be included.
-- `include_before:`, `include_after:` Custom content to be included before and after the main `content`. Both are included for each page and may be defined in terms of fields from the metadata via using `{{...}}`. Such placeholders are then processed using `glue::glue_data(meta)`, where `meta` is the list of metadata for a given page. This allows to use simple string replacements of raw HTML code (like in `include_before:` in the example) or R expression constructing HTML elements via [**htmltools**](https://cran.r-project.org/package=htmltools) (like in ``include_after:`).
+- `include_before:`, `include_after:` Custom content to be included before and after the main `content`. Both are included for each page and may be defined in terms of fields from the metadata via using `{{...}}`. Such placeholders are then processed using `glue::glue_data(meta)`, where `meta` is the list of metadata for a given page. This allows to use simple string replacements of raw HTML code (like in `include_before:` in the example) or R expression constructing HTML elements via [**htmltools**](https://cran.r-project.org/package=htmltools) (like in `include_after:`).
 
-You can see the various elements of the configuration in action in the [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example#readme) GitHub repository
+You can see the various elements of the configuration in action in the [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example#readme) GitHub repository.
 
 ### Custom templates
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/man/gallery_site.Rd
+++ b/man/gallery_site.Rd
@@ -17,7 +17,7 @@ gallery_site_generator(input, ...)
 \description{
 Define a custom website generator to be used with \code{\link[rmarkdown:render_site]{rmarkdown::render_site()}}.
 This generates a simple R Markdown website including a gallery of pages with
-embedded content, based on metadata in JSON format and custom site
+embedded content, based on metadata in JSON or YAML format and custom site
 configuration options.
 }
 \details{

--- a/man/gallery_site_config.Rd
+++ b/man/gallery_site_config.Rd
@@ -13,8 +13,9 @@ gallery_site_config(input = ".")
 The function returns the contents of \verb{_site.yml} as an \R list, with
 an additional element \verb{$gallery$meta}, a list containing the metadata of
 the pages to be generated, as read from the \code{.json}, \code{.yml} and \code{yaml}
-files, where \verb{$gallery$type_field} and \code{gallery$type_template} have been
-already used to lookup the actual \code{template}.
+files, where \verb{$gallery$type_field} and \code{gallery$type_template} (if present)
+have been already used to lookup the actual \code{template}. In addition,
+default field values specified as \code{gallery$defaults} are also applied.
 }
 \description{
 Site configuration for the \code{\link[=gallery_site]{gallery_site()}} generator.

--- a/man/gallery_site_config.Rd
+++ b/man/gallery_site_config.Rd
@@ -13,7 +13,8 @@ gallery_site_config(input = ".")
 The function returns the contents of \verb{_site.yml} as an \R list, with
 an additional element \verb{$gallery$meta}, a list containing the metadata of
 the pages to be generated, as read from the \code{.json}, \code{.yml} and \code{yaml}
-files.
+files, where \verb{$gallery$type_field} and \code{gallery$type_template} have been
+already used to lookup the actual \code{template}.
 }
 \description{
 Site configuration for the \code{\link[=gallery_site]{gallery_site()}} generator.

--- a/man/gallery_site_config.Rd
+++ b/man/gallery_site_config.Rd
@@ -12,7 +12,8 @@ gallery_site_config(input = ".")
 \value{
 The function returns the contents of \verb{_site.yml} as an \R list, with
 an additional element \verb{$gallery$meta}, a list containing the metadata of
-the pages to be generated, as read from the \code{.json} file.
+the pages to be generated, as read from the \code{.json}, \code{.yml} and \code{yaml}
+files.
 }
 \description{
 Site configuration for the \code{\link[=gallery_site]{gallery_site()}} generator.

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -32,3 +32,27 @@ test_that("Setting templates by type errors if templates are missing for certain
     ignore.case = TRUE
   )
 })
+
+test_that("Setting defaults works", {
+  defaults <- list(
+    template = "def_tpl", # partly-specified field
+    new = "def_new", # brand-new field
+    foo = "def_def" # fully-specified field
+  )
+  result <- with_defaults(meta, list(defaults = defaults))
+  expect_identical(
+    get_meta_field(result, "template"),
+    get_meta_field(meta, "template") %|NA|% defaults$template,
+    info = "partly-specified field"
+  )
+  expect_identical(
+    get_meta_field(result, "new"),
+    get_meta_field(meta, "new") %|NA|% defaults$new,
+    info = "brand-new field"
+  )
+  expect_identical(
+    get_meta_field(result, "foo"),
+    get_meta_field(meta, "foo"),
+    info = "fully-specified field"
+  )
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,0 +1,34 @@
+
+test_that("Extracting templates by type works", {
+  type <- c(a = "A", b = "C", c = "A", d = "B")
+  result <- get_type_template(type, list(A = "tplA", B = "tplB"))
+  expect_identical(
+    result,
+    c(a = "tplA", b = NA_character_,  c = "tplA", d = "tplB")
+  )
+  result <- get_type_template(type, NULL)
+  expect_identical(
+    result,
+    c(a = NA_character_, b = NA_character_,  c = NA_character_, d = NA_character_)
+  )
+})
+
+meta <- list(
+  a = list(foo = "foo", bar = "bar", type = "typeA"),
+  b = list(foo = "ofo", template = "tpl"),
+  c = list(foo = "oof", bar = "bar", type = "typeB"),
+  d = list(foo = "ofo")
+)
+
+test_that("Setting templates by type errors if templates are missing for certain types", {
+  expect_error(
+    assign_type_template(meta, "type", list(foo = "bar")),
+    glob2rx(paste("*missing*type(s)", toQuotedString(c("typeA", "typeB")))),
+    ignore.case = TRUE
+  )
+  expect_error(
+    assign_type_template(meta, "type", list(typeB = "bar")),
+    glob2rx(paste("*missing*type(s)", toQuotedString(c("typeA")))),
+    ignore.case = TRUE
+  )
+})

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -55,10 +55,10 @@ test_that("Metadata are correctly extracted from metadata files", {
   file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta.json"))
   file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
   all_meta <- read_meta(c(file_1, file_2))
-  # include tha file path as "source"
+  # include tha file path as ".meta_file"
   expected <- c(
-    lapply(meta_1, c, list(source = "meta.json")),
-    lapply(meta_2, c, list(source = "meta.yml"))
+    lapply(meta_1, c, list(.meta_file = "meta.json")),
+    lapply(meta_2, c, list(.meta_file = "meta.yml"))
   )
   expect_identical(all_meta, expected)
 })
@@ -69,10 +69,10 @@ test_that("Metadata are correctly extracted from single_meta files", {
   file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta_1.json"))
   file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta_2.yml"))
   all_meta <- read_meta(c(file_1, file_2), single = TRUE)
-  # include tha file path as "source"
+  # include tha file path as ".meta_file"
   expected <- list(
-    meta_1 = c(meta_1, list(source = "meta_1.json")),
-    meta_2 = c(meta_2, list(source = "meta_2.yml"))
+    meta_1 = c(meta_1, list(.meta_file = "meta_1.json")),
+    meta_2 = c(meta_2, list(.meta_file = "meta_2.yml"))
   )
   expect_identical(all_meta, expected)
 })

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -84,7 +84,8 @@ test_that("Duplicated names are detected across different files", {
   file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
   expect_error(
     read_meta(c(file_1, file_2)),
-    paste("duplicate", toQuotedString(c("b", "a")), sep = ".*"), ignore.case = TRUE
+    glob2rx(paste("*duplicate*metadata:", toQuotedString(c("b", "a")))),
+    ignore.case = TRUE
   )
 })
 
@@ -95,6 +96,36 @@ test_that("Duplicated names are detected across single_meta files", {
   file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
   expect_error(
     read_meta(c(file_1, file_2), single = TRUE),
-    paste("duplicate", toQuotedString("meta"), sep = ".*"), ignore.case = TRUE
+    glob2rx(paste("*duplicate*metadata:", toQuotedString("meta"))),
+    ignore.case = TRUE
   )
+})
+
+meta <- list(
+  a = list(foo = "foo", bar = "bar", dummy = "dummy"),
+  b = list(foo = "ofo", dummy = "dummy"),
+  c = list(foo = "oof", bar = "bar", dummy = "dummy")
+)
+
+test_that("Extracting a metadata field works", {
+  expect_identical(
+    get_meta_field(meta, "foo"),
+    c(a = "foo", b = "ofo", c = "oof")
+  )
+  expect_identical(
+    get_meta_field(meta, "bar"),
+    c(a = "bar", b = NA_character_, c = "bar")
+  )
+})
+
+test_that("Setting a metadata field works", {
+  expect_identical(
+    set_meta_field(meta, "bar", letters[3:1]),
+    Map(`[[<-`, meta, "bar", letters[3:1])
+  )
+  expect_identical(
+    set_meta_field(meta, "foo", c("a", NA_character_, "c")),
+    Map(`[[<-`, meta, "foo", list("a", NULL, "c"))
+  )
+
 })

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -1,0 +1,100 @@
+meta_ext <- c(".json", ".yml", ".yaml")
+meta_writer <- list(
+  .json = function(...) jsonlite::write_json(..., auto_unbox = TRUE),
+  .yml = yaml::write_yaml,
+  .yaml = yaml::write_yaml
+)
+
+.write_meta <- function(meta, file) {
+  ext <- sprintf(".%s", tools::file_ext(file))
+  meta_writer[[ext]](meta, file)
+  file
+}
+
+test_that("Metadata files with supported extensions are detected", {
+  meta_dir <- tempfile("meta")
+  dir.create(meta_dir)
+  meta_files <- tempfile(tmpdir = meta_dir, fileext = meta_ext)
+  other_files <- tempfile(tmpdir = meta_dir, fileext = c(".foo", ".bar", ""))
+  file.create(c(meta_files, other_files))
+  message(site_meta_files(meta_dir))
+  testthat::expect_setequal(
+    site_meta_files(meta_dir),
+    meta_files
+  )
+  unlink(meta_dir, recursive = TRUE)
+})
+
+# include some characters requiring escaping
+meta <- list(
+  "f\"o'o" = 'foo "bar" \n \\foo\\ \'bar\'',
+  bar = list(
+    barfoo = "bar foo",
+    foobar = "foo bar"
+  )
+)
+
+test_that("Metadata files with supported extensions are read correctly", {
+  mapply(
+    function(ext) {
+      file <- .write_meta(meta, tempfile(fileext = ext))
+      expect_identical(
+        read_meta_file(file),
+        meta,
+        info = ext
+      )
+      unlink(file)
+    },
+    meta_ext
+  )
+})
+
+test_that("Metadata are correctly extracted from metadata files", {
+  meta_1 <- list(a = meta, b = meta)
+  meta_2 <- list(c = meta, d = meta)
+  file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta.json"))
+  file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
+  all_meta <- read_meta(c(file_1, file_2))
+  # include tha file path as "source"
+  expected <- c(
+    lapply(meta_1, c, list(source = "meta.json")),
+    lapply(meta_2, c, list(source = "meta.yml"))
+  )
+  expect_identical(all_meta, expected)
+})
+
+test_that("Metadata are correctly extracted from single_meta files", {
+  meta_1 <- meta
+  meta_2 <- meta
+  file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta_1.json"))
+  file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta_2.yml"))
+  all_meta <- read_meta(c(file_1, file_2), single = TRUE)
+  # include tha file path as "source"
+  expected <- list(
+    meta_1 = c(meta_1, list(source = "meta_1.json")),
+    meta_2 = c(meta_2, list(source = "meta_2.yml"))
+  )
+  expect_identical(all_meta, expected)
+})
+
+test_that("Duplicated names are detected across different files", {
+  meta_1 <- list(a = meta, b = meta, c = meta)
+  meta_2 <- list(d = meta, b = meta, a = meta)
+  file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta.json"))
+  file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
+  expect_error(
+    read_meta(c(file_1, file_2)),
+    paste("duplicate", toQuotedString(c("b", "a")), sep = ".*"), ignore.case = TRUE
+  )
+})
+
+test_that("Duplicated names are detected across single_meta files", {
+  meta_1 <- meta
+  meta_2 <- meta
+  file_1 <- .write_meta(meta_1, file.path(tempdir(), "meta.json"))
+  file_2 <- .write_meta(meta_2, file.path(tempdir(), "meta.yml"))
+  expect_error(
+    read_meta(c(file_1, file_2), single = TRUE),
+    paste("duplicate", toQuotedString("meta"), sep = ".*"), ignore.case = TRUE
+  )
+})

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -127,5 +127,17 @@ test_that("Setting a metadata field works", {
     set_meta_field(meta, "foo", c("a", NA_character_, "c")),
     Map(`[[<-`, meta, "foo", list("a", NULL, "c"))
   )
+})
 
+test_that("Get/set round-trip does not alter metadata", {
+  meta <- list(
+    a = list(foo = "A"),
+    b = list(foo = "B"),
+    c = list(bar = "C"),
+    d = list(foo = "D")
+  )
+  expect_identical(
+    set_meta_field(meta, "foo", get_meta_field(meta, "foo")),
+    meta
+  )
 })


### PR DESCRIPTION
## New features

- Metadata in YAML format are now also supported (#2).
- Custom _page types_ are now supported as an alternative to the `template` field of the metadata. Page types are defined and mapped to actual templates in the `gallery` site configuration, using new fields `type_field` and `type_template` (#4).
- Default values for unspecified fields in the metadata can now be defined using the new `defaults` field in the `gallery` site configuration (#3).

## Maintenance

- Updated package README to cover new features and point to branch `develop` for using the development version.
- Extended test coverage for new as well as existing utilities.
