### PR TITLE
Fix handling of missing `type_field`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# rmdgallery 0.2.1
+
+## Patch release
+
+- Fix handling of missing `type_field` in the `gallery` site configuration (#10).
+
 # rmdgallery 0.2.0
 
 ## New features

--- a/R/config.R
+++ b/R/config.R
@@ -27,7 +27,7 @@ gallery_site_config <- function(input = ".") {
   config
 }
 
-with_type_template <- function(meta, gallery_config)(
+with_type_template <- function(meta, gallery_config) {
   if (!is.null(gallery_config$type_field)) {
     meta <- assign_type_template(
       meta,
@@ -35,7 +35,8 @@ with_type_template <- function(meta, gallery_config)(
       gallery_config$type_template
     )
   }
-)
+  meta
+}
 
 assign_type_template <- function(meta, type_field, type_templates) {
   template <- get_meta_field(meta, "template")

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -33,6 +33,13 @@ test_that("Setting templates by type errors if templates are missing for certain
   )
 })
 
+test_that("Setting templates by type handles no type_field", {
+  expect_identical(
+    with_type_template(meta, list()),
+    meta
+  )
+})
+
 test_that("Setting defaults works", {
   defaults <- list(
     template = "def_tpl", # partly-specified field


### PR DESCRIPTION
Metadata were returned as `NULL` as opposed to being unchanged.
This is now covered by a unit test.