### PR TITLE
Release v0.2.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.2.1.9000
+Version: 0.2.2
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- The `gallery_site()` generator now works when `rmarkdown::render_site()` is called on a directory other than the current (#11).
+
 # rmdgallery 0.2.1
 
 ## Patch release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rmdgallery (development version)
+
 # rmdgallery 0.2.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# rmdgallery (development version)
+# rmdgallery 0.2.2
 
-- The `gallery_site()` generator now works when `rmarkdown::render_site()` is called on a directory other than the current (#11).
+## Patch release
+
+- The `gallery_site()` generator now works when `rmarkdown::render_site()` is called with any path to a directory containing the website sources (#11).
 
 # rmdgallery 0.2.1
 

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -121,7 +121,8 @@ gallery_site <- function(input, ...) {
         if (!quiet) message("\nMetadata from: ", meta$.meta_file)
         # gallery config:
         meta$gallery_config <- if (is.null(config$gallery)) list() else config$gallery
-        output_file <- file.path(input, file_with_ext(name, "html"))
+        output_file <- name # extension and directory are included by rmarkdown::render
+
         x <- file.path(input, file_with_ext(sprintf(".tmp_%s", name), "Rmd"))
         template_dir <- if (!is.null(config$gallery$template_dir)) {
           file.path(input, config$gallery$template_dir)
@@ -134,9 +135,9 @@ gallery_site <- function(input, ...) {
 
       # make some useful utils available when rendering
       envir <- list2env(render_time_utils, parent = envir)
-
       output <- render_one(input = x,
-                           output_format = output_format, output_file = output_file,
+                           output_format = output_format,
+                           output_file = output_file,
                            output_options = list(lib_dir = "site_libs",
                                                  self_contained = FALSE),
                            params = knit_params,


### PR DESCRIPTION
## Patch release

- The `gallery_site()` generator now works when `rmarkdown::render_site()` is called with any path to a directory containing the website sources (#11).
