### PR TITLE
New `order_by` configuration + `page_name` metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
+- A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
 - `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
 
 # rmdgallery 0.2.2

--- a/R/config.R
+++ b/R/config.R
@@ -19,6 +19,7 @@ gallery_site_config <- function(input = ".") {
     single_meta <- config$gallery$single_meta %||% FALSE
     meta_files <- site_meta_files(file.path(input, meta_dir))
     meta <- read_meta(meta_files, single_meta)
+    meta <- with_name_field(meta, "page_name")
     meta <- with_type_template(meta, config$gallery)
     meta <- with_defaults(meta, config$gallery)
     check_missing_template(meta)

--- a/R/config.R
+++ b/R/config.R
@@ -22,6 +22,7 @@ gallery_site_config <- function(input = ".") {
     meta <- with_name_field(meta, "page_name")
     meta <- with_type_template(meta, config$gallery)
     meta <- with_defaults(meta, config$gallery)
+    meta <- sort_meta(meta, config$gallery$order_by %||% "page_name")
     check_missing_template(meta)
     config$gallery$meta <- meta
     config$gallery <- with_includes(config$gallery, input)

--- a/R/config.R
+++ b/R/config.R
@@ -9,7 +9,10 @@
 #'   the pages to be generated, as read from the `.json`, `.yml` and `yaml`
 #'   files, where `$gallery$type_field` and `gallery$type_template` (if present)
 #'   have been already used to lookup the actual `template`. In addition,
-#'   default field values specified as `gallery$defaults` are also applied.
+#'   default field values specified as `gallery$defaults` are also applied. The
+#'   metadata in `$gallery$meta` also include an additional field `page_name`
+#'   containing the names of the metadata list itself, serving as names for the
+#'   HTML pages that will be generated.
 #'
 #' @export
 gallery_site_config <- function(input = ".") {

--- a/R/meta.R
+++ b/R/meta.R
@@ -55,3 +55,14 @@ set_meta_field <- function(meta, field, value) {
     meta, value
   )
 }
+
+with_name_field <- function(meta, name_field) {
+  name_values <- get_meta_field(meta, name_field)
+  # the specified field should not exist
+  if (any(!is.na(name_values))) {
+    stop(
+      "Field ", toQuotedString(name_field), " cannot be used",
+      " for storing the matadata names since it is already in use.")
+  }
+  set_meta_field(meta, name_field, names(meta))
+}

--- a/R/meta.R
+++ b/R/meta.R
@@ -66,3 +66,29 @@ with_name_field <- function(meta, name_field) {
   }
   set_meta_field(meta, name_field, names(meta))
 }
+
+parse_order_by <- function(by) {
+  pattern <- "^desc\\((.*))$"
+  decreasing <- grepl(pattern, by)
+  field <- sub(pattern, "\\1", by)
+  list(
+    field = field,
+    decreasing = decreasing
+  )
+}
+
+as_sorted_factor <- function(x, decreasing = FALSE) {
+  factor(x, sort(unique(x), decreasing = decreasing))
+}
+
+sort_meta <- function(meta, by = character(0)) {
+  parsed <- parse_order_by(by)
+  factors <- Map(
+    as_sorted_factor,
+    Map(get_meta_field, parsed$field, MoreArgs = list(meta = meta)),
+    parsed$decreasing
+  )
+  # always include the names as (last) criterion
+  factors$..names.. <- names(meta)
+  meta[do.call(order, factors)]
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ navbar:
 gallery:
   meta_dir: "meta"
   single_meta: false
+  order_by: [page_name, ...]
   template_dir: "path/to/cutom/templates"
   type_field: my_type
   type_template:
@@ -134,6 +135,7 @@ gallery:
 
 - `meta_dir:` Optional name of the directory containing `.json`, `.yml` and `.yaml` metadata files. Defaults to `meta` if not specified.
 - `single_meta:` Optional `true` or `false` defining whether the files define metadata for individual pages, in which case e.g. a file `foo.json` would contain only the metadata for the `foo.html` page. Defaults to `false` if not specified.
+- `order_by`: Optional fields used to sort the list of metadata. If missing, the default `page_name` is a field added by **rmdgallery** containing the name of the entry in the metadata list for each page.
 - `template_dir:` Optional location of additional custom templates.
 - `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
 - `defaults:` Optional list of default values for unspecified metadata fields.

--- a/man/gallery_site_config.Rd
+++ b/man/gallery_site_config.Rd
@@ -15,7 +15,10 @@ an additional element \verb{$gallery$meta}, a list containing the metadata of
 the pages to be generated, as read from the \code{.json}, \code{.yml} and \code{yaml}
 files, where \verb{$gallery$type_field} and \code{gallery$type_template} (if present)
 have been already used to lookup the actual \code{template}. In addition,
-default field values specified as \code{gallery$defaults} are also applied.
+default field values specified as \code{gallery$defaults} are also applied. The
+metadata in \verb{$gallery$meta} also include an additional field \code{page_name}
+containing the names of the metadata list itself, serving as names for the
+HTML pages that will be generated.
 }
 \description{
 Site configuration for the \code{\link[=gallery_site]{gallery_site()}} generator.

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -141,3 +141,28 @@ test_that("Get/set round-trip does not alter metadata", {
     meta
   )
 })
+
+test_that("Metadata name field is added correctly", {
+  meta <- list(
+    a = list(foo = "A"), b = list(foo = "B"), c = list(foo = "C")
+  )
+  expected <- meta
+  expected$a$name <- "a"
+  expected$b$name <- "b"
+  expected$c$name <- "c"
+  expect_identical(
+    with_name_field(meta, "name"),
+    expected
+  )
+})
+
+test_that("Error if the name field is already present correctly", {
+  meta <- list(
+    a = list(foo = "A"), b = list(foo = "B", name = "_b_"), c = list(foo = "C")
+  )
+  expect_error(
+    with_name_field(meta, "name"),
+    glob2rx(paste("*", toQuotedString("name"), "*already in use*")),
+    ignore.case = TRUE
+  )
+})

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -166,3 +166,36 @@ test_that("Error if the name field is already present correctly", {
     ignore.case = TRUE
   )
 })
+
+test_that("`order_by` configuration is parsed correctly" , {
+  expect_identical(
+    parse_order_by(c("foo", "desc(bar)", "desc(foo(bar))", "foo(desc(bar))")),
+    list(
+      field = c("foo", "bar", "foo(bar)", "foo(desc(bar))"),
+      decreasing = c(FALSE, TRUE, TRUE, FALSE)
+    )
+  )
+})
+
+test_that("Metadata are ordered correctly", {
+  meta <- list(
+    b = list(foo = "A", bar = "B", zoo = "A"), # 2
+    d = list(foo = "B", bar = "B", zoo = "B"), # 5
+    e = list(foo = "B", bar = "B", zoo = "A"), # 1
+    a = list(           bar = "B", zoo = "A"), # 3
+    c = list(foo = "B", bar = "B", zoo = "B")  # 4
+  )
+  expect_identical(
+    sort_meta(meta, by = c("zoo", "desc(foo)")),
+    meta[c("e", "b", "a", "c", "d")]
+  )
+  expect_identical(
+    sort_meta(meta),
+    meta[letters[1:5]]
+  )
+  expect_identical(
+    sort_meta(meta, "dummy"),
+    meta[letters[1:5]]
+  )
+})
+


### PR DESCRIPTION
Closes #15.

Tested and showcased in [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example), with rmdgallery built from the feature branch.