### PR TITLE
Support gallery menu icons in the metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rmdgallery (development version)
 
+- Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
 - A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
 - A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
 - `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -40,41 +40,6 @@ gallery_site <- function(input, ...) {
     files[!grepl("^README\\.R?md$", files)]
   }
 
-  # helper function constructing the gallery navbar entry
-  navbar_with_gallery <- function() {
-    if (!is.null(config$gallery$navbar)) {
-      gallery_navbar <- config$gallery$navbar
-      meta <- config$gallery$meta
-      # must have one element, which is the location, e.g. $left
-      stopifnot(length(gallery_navbar) == 1L)
-      gallery_links <- file_with_ext(names(meta), "html")
-      gallery_entry <- vapply(meta, FUN.VALUE = "", function(x) {
-        x$menu_entry %||% NA_character_
-      })
-      has_entry <- !is.na(gallery_entry)
-      duplicated <- duplicated(gallery_entry[has_entry])
-      if (any(duplicated)) {
-        stop(
-          "Found duplicate navbar menu entries: ",
-          toQuotedString(gallery_entry[has_entry][duplicated]))
-      }
-      gallery_navbar[[1L]][[1]]$menu <- mapply(
-        SIMPLIFY = FALSE, USE.NAMES = FALSE,
-        function(text, href) {
-          list(text = text, href = href)
-        },
-        gallery_entry[has_entry], gallery_links[has_entry]
-      )
-      # add to the user-defined navbar from the main site configuration
-      navbar <- config$navbar
-      navbar[[names(gallery_navbar)]] <- c(
-        navbar[[names(gallery_navbar)]],
-        gallery_navbar[[1]]
-      )
-      navbar
-    }
-  }
-
   # define render function (use ... to gracefully handle future args)
   render <- function(input_file,
                      output_format,
@@ -82,8 +47,8 @@ gallery_site <- function(input, ...) {
                      quiet,
                      ...) {
 
-    navbar <- navbar_with_gallery()
-    if (!is.null(navbar) == 1L) {
+    navbar <- navbar_with_gallery(config)
+    if (!is.null(navbar)) {
       custom_navbar <- file.path(input, "_navbar.html")
       file.copy(rmarkdown::navbar_html(navbar), custom_navbar, overwrite = TRUE)
       on.exit(unlink(custom_navbar))

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ foo:
 bar: 
   title: Embed content from an external URL
   menu_entry: URL example
+  menu_icon: fa-gear
   template: embed-url
   content: https://example.com
 ```
-defines the metadata for pages rendered as `foo.html` and `bar.html` with the given page `title`, also adding the specified `menu_entry` to the [site navigation bar](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site-navigation).
+defines the metadata for pages rendered as `foo.html` and `bar.html` with the given page `title`, also adding the specified `menu_entry` to the [site navigation bar](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site-navigation). The entry for `bar.html` in the site navigation bar will also include the specified `menu_icon`.
 
 The way metadata, especially the `content`, are used to produce the resulting page depends on the specified `template`. Templates might in general make use of additional specific metadata fields, which can also be used for additional content included in the custom site [configuration](#configuration-and-customization).
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -63,3 +63,98 @@ test_that("Setting defaults works", {
     info = "fully-specified field"
   )
 })
+
+test_that("navbar_menu_entry() behaves correctly", {
+  # separate menu_fields
+  meta_fields <- list(
+    menu_entry = "txt", menu_icon = "ico", page_name = "foo"
+  )
+  # single field with text and icon elements
+  meta_navbar <- list(
+    menu_entry = list(text = "txt", icon = "ico"), page_name = "foo"
+  )
+  expected <- list(
+    text = "txt", icon = "ico", href = "foo.html"
+  )
+  expect_null(navbar_menu_entry(list()))
+  expect_equal(
+    navbar_menu_entry(meta_fields[c("menu_entry", "page_name")]),
+    expected[c("text", "href")]
+  )
+  expect_equal(
+    navbar_menu_entry(meta_fields[c("menu_icon", "page_name")]),
+    expected[c("icon", "href")]
+  )
+  expect_equal(
+    navbar_menu_entry(meta_fields),
+    expected
+  )
+  expect_equal(
+    navbar_menu_entry(meta_navbar),
+    expected
+  )
+})
+
+meta <- list(
+  a = list(menu_entry = "txta", menu_icon = "ico", page_name = "foo"),
+  b = list(menu_entry = "txtb", menu_icon = "ico", page_name = "bar")
+)
+
+test_that("The gallery navbar menu is constructed correctly", {
+  meta <- list(
+    a = list(menu_entry = "txta", menu_icon = "ico", page_name = "foo"),
+    b = list(menu_entry = "txtb", menu_icon = "ico", page_name = "bar")
+  )
+  expected <- list(
+    list(text = "txta", icon = "ico", href = "foo.html"),
+    list(text = "txtb", icon = "ico", href = "bar.html")
+  )
+  expect_equal(
+    gallery_navbar_menu(meta),
+    expected
+  )
+  # error on duplicated keys
+  meta$b <- meta$a
+  expect_error(
+    gallery_navbar_menu(meta),
+    glob2rx(paste("*duplicate*", toQuotedString("ico txta"))),
+    ignore.case = TRUE
+  )
+})
+
+test_that("The gallery navbar is added correctly", {
+  config <- list(
+    navbar = list(
+      left = list(list(text = "home", href = "home.html")),
+      right = list(list(text = "office", href = "office.html"))
+    ),
+    gallery = list(
+      navbar = list(left = list(list(text = "gallery"))),
+      meta = meta
+    )
+  )
+  expected <- config$navbar
+  expected$left <- c(
+    expected$left,
+    list(list(text = "gallery", menu = gallery_navbar_menu(meta)))
+  )
+  expect_equal(
+    navbar_with_gallery(config),
+    expected
+  )
+
+  # no gallery$navbar
+  expect_equal(
+    navbar_with_gallery(config["navbar"]),
+    config$navbar
+  )
+  # only gallery$navbar
+  expect_equal(
+    navbar_with_gallery(config["gallery"]),
+    list(left = expected$left[2])
+  )
+  # no gallery$navbar
+  expect_null(
+    navbar_with_gallery(list(dummy = "dummy"))
+  )
+})


### PR DESCRIPTION
Closes #16.

Tested and showcased in [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example), with rmdgallery built from the feature branch.