### PR TITLE
Release v0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.2.2.9000
+Version: 0.3.0
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.2.2
+Version: 0.2.2.9000
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,10 +7,9 @@
 - A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
 - Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
 
-# Fix
+## Minor fix
 
 - The `gallery_site()` generator now works with an empty list of metadata (#20).
-
 
 # rmdgallery 0.2.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
+
 # rmdgallery 0.2.2
 
 ## Patch release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rmdgallery (development version)
 
+- Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
 - A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
 - A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
 - `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # rmdgallery (development version)
 
+- The `gallery_site()` generator now works with an empty list of metadata (#20).
 - Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
 - A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
 - A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
+- A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
 - `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
 
 # rmdgallery 0.2.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rmdgallery (development version)
+
 # rmdgallery 0.2.2
 
 ## Patch release

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
-# rmdgallery (development version)
+# rmdgallery 0.3.0
 
-- The `gallery_site()` generator now works with an empty list of metadata (#20).
-- Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
+## New features
+
+- `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
 - A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
 - A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
-- `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
+- Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).
+
+# Fix
+
+- The `gallery_site()` generator now works with an empty list of metadata (#20).
+
 
 # rmdgallery 0.2.2
 

--- a/R/config.R
+++ b/R/config.R
@@ -23,6 +23,7 @@ gallery_site_config <- function(input = ".") {
     meta <- with_defaults(meta, config$gallery)
     check_missing_template(meta)
     config$gallery$meta <- meta
+    config$gallery <- with_includes(config$gallery, input)
   }
   config
 }
@@ -43,7 +44,7 @@ assign_type_template <- function(meta, type_field, type_templates) {
   type <- get_meta_field(meta, type_field)
   with_type <- is.na(template) & !is.na(type)
   template_from_type <- get_type_template(type[with_type], type_templates)
-  miss_template <- is.na(template_from_type )
+  miss_template <- is.na(template_from_type)
   if (any(miss_template)) {
     stop(
       "Missing template specification for custom type(s) ",
@@ -85,3 +86,24 @@ check_missing_template <- function(meta) {
   invisible(meta)
 }
 
+with_includes <- function(gallery_config, path = ".") {
+  includes <- intersect(
+    c("include_before", "include_after"),
+    names(gallery_config)
+  )
+  gallery_config[includes] <- lapply(
+    gallery_config[includes], function(include) {
+      include_file <- file.path(path, include)
+      if (!file.exists(include_file)) {
+        .Deprecated(msg = paste(
+          "Inline definition of `include_before` and `include_after` is deprecated.",
+          "They should define the path to a file with the content to be included."
+        ))
+        include
+      } else {
+        paste(readLines(include_file), collapse = "\n")
+      }
+    }
+  )
+  gallery_config
+}

--- a/R/config.R
+++ b/R/config.R
@@ -19,6 +19,7 @@ gallery_site_config <- function(input = ".") {
     single_meta <- config$gallery$single_meta %||% FALSE
     meta_files <- site_meta_files(file.path(input, meta_dir))
     meta <- read_meta(meta_files, single_meta)
+    meta <- with_name_field(meta, "page_name")
     meta <- with_type_template(meta, config$gallery)
     meta <- with_defaults(meta, config$gallery)
     check_missing_template(meta)

--- a/R/config.R
+++ b/R/config.R
@@ -22,6 +22,7 @@ gallery_site_config <- function(input = ".") {
     meta <- with_name_field(meta, "page_name")
     meta <- with_type_template(meta, config$gallery)
     meta <- with_defaults(meta, config$gallery)
+    meta <- sort_meta(meta, config$gallery$order_by %||% "page_name")
     check_missing_template(meta)
     config$gallery$meta <- meta
     config$gallery <- with_includes(config$gallery, input)

--- a/R/config.R
+++ b/R/config.R
@@ -9,7 +9,10 @@
 #'   the pages to be generated, as read from the `.json`, `.yml` and `yaml`
 #'   files, where `$gallery$type_field` and `gallery$type_template` (if present)
 #'   have been already used to lookup the actual `template`. In addition,
-#'   default field values specified as `gallery$defaults` are also applied.
+#'   default field values specified as `gallery$defaults` are also applied. The
+#'   metadata in `$gallery$meta` also include an additional field `page_name`
+#'   containing the names of the metadata list itself, serving as names for the
+#'   HTML pages that will be generated.
 #'
 #' @export
 gallery_site_config <- function(input = ".") {

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -40,41 +40,6 @@ gallery_site <- function(input, ...) {
     files[!grepl("^README\\.R?md$", files)]
   }
 
-  # helper function constructing the gallery navbar entry
-  navbar_with_gallery <- function() {
-    if (!is.null(config$gallery$navbar)) {
-      gallery_navbar <- config$gallery$navbar
-      meta <- config$gallery$meta
-      # must have one element, which is the location, e.g. $left
-      stopifnot(length(gallery_navbar) == 1L)
-      gallery_links <- file_with_ext(names(meta), "html")
-      gallery_entry <- vapply(meta, FUN.VALUE = "", function(x) {
-        x$menu_entry %||% NA_character_
-      })
-      has_entry <- !is.na(gallery_entry)
-      duplicated <- duplicated(gallery_entry[has_entry])
-      if (any(duplicated)) {
-        stop(
-          "Found duplicate navbar menu entries: ",
-          toQuotedString(gallery_entry[has_entry][duplicated]))
-      }
-      gallery_navbar[[1L]][[1]]$menu <- mapply(
-        SIMPLIFY = FALSE, USE.NAMES = FALSE,
-        function(text, href) {
-          list(text = text, href = href)
-        },
-        gallery_entry[has_entry], gallery_links[has_entry]
-      )
-      # add to the user-defined navbar from the main site configuration
-      navbar <- config$navbar
-      navbar[[names(gallery_navbar)]] <- c(
-        navbar[[names(gallery_navbar)]],
-        gallery_navbar[[1]]
-      )
-      navbar
-    }
-  }
-
   # define render function (use ... to gracefully handle future args)
   render <- function(input_file,
                      output_format,
@@ -82,8 +47,8 @@ gallery_site <- function(input, ...) {
                      quiet,
                      ...) {
 
-    navbar <- navbar_with_gallery()
-    if (!is.null(navbar) == 1L) {
+    navbar <- navbar_with_gallery(config)
+    if (!is.null(navbar)) {
       custom_navbar <- file.path(input, "_navbar.html")
       file.copy(rmarkdown::navbar_html(navbar), custom_navbar, overwrite = TRUE)
       on.exit(unlink(custom_navbar))

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -67,7 +67,9 @@ gallery_site <- function(input, ...) {
     else {
       files <- file.path(input, input_files())
     }
-    files <- c(files, file_with_ext(names(config$gallery$meta), "meta"))
+    if (length(config$gallery$meta) > 0L) {
+      files <- c(files, file_with_ext(names(config$gallery$meta), "meta"))
+    }
 
     sapply(files, function(x) {
       render_one <- if (isTRUE(config$new_session)) {

--- a/R/meta.R
+++ b/R/meta.R
@@ -55,3 +55,14 @@ set_meta_field <- function(meta, field, value) {
     meta, value
   )
 }
+
+with_name_field <- function(meta, name_field) {
+  name_values <- get_meta_field(meta, name_field)
+  # the specified field should not exist
+  if (any(!is.na(name_values))) {
+    stop(
+      "Field ", toQuotedString(name_field), " cannot be used",
+      " for storing the matadata names since it is already in use.")
+  }
+  set_meta_field(meta, name_field, names(meta))
+}

--- a/R/meta.R
+++ b/R/meta.R
@@ -66,3 +66,29 @@ with_name_field <- function(meta, name_field) {
   }
   set_meta_field(meta, name_field, names(meta))
 }
+
+parse_order_by <- function(by) {
+  pattern <- "^desc\\((.*))$"
+  decreasing <- grepl(pattern, by)
+  field <- sub(pattern, "\\1", by)
+  list(
+    field = field,
+    decreasing = decreasing
+  )
+}
+
+as_sorted_factor <- function(x, decreasing = FALSE) {
+  factor(x, sort(unique(x), decreasing = decreasing))
+}
+
+sort_meta <- function(meta, by = character(0)) {
+  parsed <- parse_order_by(by)
+  factors <- Map(
+    as_sorted_factor,
+    Map(get_meta_field, parsed$field, MoreArgs = list(meta = meta)),
+    parsed$decreasing
+  )
+  # always include the names as (last) criterion
+  factors$..names.. <- names(meta)
+  meta[do.call(order, factors)]
+}

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ navbar:
 gallery:
   meta_dir: "meta"
   single_meta: false
+  order_by: [page_name, ...]
   template_dir: "path/to/cutom/templates"
   type_field: my_type
   type_template:
@@ -134,6 +135,7 @@ gallery:
 
 - `meta_dir:` Optional name of the directory containing `.json`, `.yml` and `.yaml` metadata files. Defaults to `meta` if not specified.
 - `single_meta:` Optional `true` or `false` defining whether the files define metadata for individual pages, in which case e.g. a file `foo.json` would contain only the metadata for the `foo.html` page. Defaults to `false` if not specified.
+- `order_by`: Optional fields used to sort the list of metadata. If missing, the default `page_name` is a field added by **rmdgallery** containing the name of the entry in the metadata list for each page.
 - `template_dir:` Optional location of additional custom templates.
 - `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
 - `defaults:` Optional list of default values for unspecified metadata fields.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ navbar:
 gallery:
   meta_dir: "meta"
   single_meta: false
-  order_by: [page_name, ...]
+  order_by: [title, desc(another_field)]
   template_dir: "path/to/cutom/templates"
   type_field: my_type
   type_template:
@@ -135,7 +135,7 @@ gallery:
 
 - `meta_dir:` Optional name of the directory containing `.json`, `.yml` and `.yaml` metadata files. Defaults to `meta` if not specified.
 - `single_meta:` Optional `true` or `false` defining whether the files define metadata for individual pages, in which case e.g. a file `foo.json` would contain only the metadata for the `foo.html` page. Defaults to `false` if not specified.
-- `order_by`: Optional fields used to sort the list of metadata. If missing, the default `page_name` is a field added by **rmdgallery** containing the name of the entry in the metadata list for each page.
+- `order_by`: Optional fields used to sort the list of metadata. Use `desc(<field>)` for decreasing order. If missing, the default `page_name` is a field added by **rmdgallery** containing the name of the entry in the metadata list for each page.
 - `template_dir:` Optional location of additional custom templates.
 - `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
 - `defaults:` Optional list of default values for unspecified metadata fields.

--- a/README.md
+++ b/README.md
@@ -128,14 +128,8 @@ gallery:
     left:
       - text: "Gallery"
         icon: fa-gear
-  include_before: |
-    <hr>include_before for {{title}}<hr/>
-  after: |
-    {{htmltools::tagList(
-        htmltools::hr(),
-        "include_after for", title,
-        htmltools::hr()
-    )}}
+  include_before: _includes/before_gallery.html
+  include_after: _includes/after_gallery.R
 ```
 
 - `meta_dir:` Optional name of the directory containing `.json`, `.yml` and `.yaml` metadata files. Defaults to `meta` if not specified.
@@ -144,7 +138,16 @@ gallery:
 - `type_field:`, `type_template:` Optional fields defining custom page _types_ (see ['Page types'](#page-types) above).
 - `defaults:` Optional list of default values for unspecified metadata fields.
 - `navbar:` The gallery navigation menu to be included in the standard `navbar:` of `_site.yml`. The menu is populated with the `menu_entry` of each page from the metadata. Can be omitted if no such menu should be included.
-- `include_before:`, `include_after:` Custom content to be included before and after the main `content`. Both are included for each page and may be defined in terms of fields from the metadata via using `{{...}}`. Such placeholders are then processed using `glue::glue_data(meta)`, where `meta` is the list of metadata for a given page. This allows to use simple string replacements of raw HTML code (like in `include_before:` in the example) or R expression constructing HTML elements via [**htmltools**](https://cran.r-project.org/package=htmltools) (like in `include_after:`).
+- `include_before:`, `include_after:` Optional path to files defining custom content included before and after the main `content`. Both are included for each page and may be defined in terms of fields from the metadata using `{{...}}`. Such placeholders are then processed using `glue::glue_data(meta)`, where `meta` is the list of metadata for a given page. This allows to use simple string replacements in raw HTML code, as in the following example of `_includes/before_gallery.html`
+  ``` html
+  <hr>include_before for {{title}}<hr/>
+  ```
+  but also to define complete R expressions constructing HTML elements via [**htmltools**](https://cran.r-project.org/package=htmltools), as in the following `_includes/after_gallery.R`:
+  ``` r
+  {{htmltools::tagList(
+      htmltools::hr(), "include_after for", title, htmltools::hr()
+  )}}
+  ```
 
 You can see the various elements of the configuration in action in the [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example#readme) GitHub repository.
 

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ foo:
 bar: 
   title: Embed content from an external URL
   menu_entry: URL example
+  menu_icon: fa-gear
   template: embed-url
   content: https://example.com
 ```
-defines the metadata for pages rendered as `foo.html` and `bar.html` with the given page `title`, also adding the specified `menu_entry` to the [site navigation bar](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site-navigation).
+defines the metadata for pages rendered as `foo.html` and `bar.html` with the given page `title`, also adding the specified `menu_entry` to the [site navigation bar](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html#site-navigation). The entry for `bar.html` in the site navigation bar will also include the specified `menu_icon`.
 
 The way metadata, especially the `content`, are used to produce the resulting page depends on the specified `template`. Templates might in general make use of additional specific metadata fields, which can also be used for additional content included in the custom site [configuration](#configuration-and-customization).
 

--- a/man/gallery_site_config.Rd
+++ b/man/gallery_site_config.Rd
@@ -15,7 +15,10 @@ an additional element \verb{$gallery$meta}, a list containing the metadata of
 the pages to be generated, as read from the \code{.json}, \code{.yml} and \code{yaml}
 files, where \verb{$gallery$type_field} and \code{gallery$type_template} (if present)
 have been already used to lookup the actual \code{template}. In addition,
-default field values specified as \code{gallery$defaults} are also applied.
+default field values specified as \code{gallery$defaults} are also applied. The
+metadata in \verb{$gallery$meta} also include an additional field \code{page_name}
+containing the names of the metadata list itself, serving as names for the
+HTML pages that will be generated.
 }
 \description{
 Site configuration for the \code{\link[=gallery_site]{gallery_site()}} generator.

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -63,3 +63,98 @@ test_that("Setting defaults works", {
     info = "fully-specified field"
   )
 })
+
+test_that("navbar_menu_entry() behaves correctly", {
+  # separate menu_fields
+  meta_fields <- list(
+    menu_entry = "txt", menu_icon = "ico", page_name = "foo"
+  )
+  # single field with text and icon elements
+  meta_navbar <- list(
+    menu_entry = list(text = "txt", icon = "ico"), page_name = "foo"
+  )
+  expected <- list(
+    text = "txt", icon = "ico", href = "foo.html"
+  )
+  expect_null(navbar_menu_entry(list()))
+  expect_equal(
+    navbar_menu_entry(meta_fields[c("menu_entry", "page_name")]),
+    expected[c("text", "href")]
+  )
+  expect_equal(
+    navbar_menu_entry(meta_fields[c("menu_icon", "page_name")]),
+    expected[c("icon", "href")]
+  )
+  expect_equal(
+    navbar_menu_entry(meta_fields),
+    expected
+  )
+  expect_equal(
+    navbar_menu_entry(meta_navbar),
+    expected
+  )
+})
+
+meta <- list(
+  a = list(menu_entry = "txta", menu_icon = "ico", page_name = "foo"),
+  b = list(menu_entry = "txtb", menu_icon = "ico", page_name = "bar")
+)
+
+test_that("The gallery navbar menu is constructed correctly", {
+  meta <- list(
+    a = list(menu_entry = "txta", menu_icon = "ico", page_name = "foo"),
+    b = list(menu_entry = "txtb", menu_icon = "ico", page_name = "bar")
+  )
+  expected <- list(
+    list(text = "txta", icon = "ico", href = "foo.html"),
+    list(text = "txtb", icon = "ico", href = "bar.html")
+  )
+  expect_equal(
+    gallery_navbar_menu(meta),
+    expected
+  )
+  # error on duplicated keys
+  meta$b <- meta$a
+  expect_error(
+    gallery_navbar_menu(meta),
+    glob2rx(paste("*duplicate*", toQuotedString("ico txta"))),
+    ignore.case = TRUE
+  )
+})
+
+test_that("The gallery navbar is added correctly", {
+  config <- list(
+    navbar = list(
+      left = list(list(text = "home", href = "home.html")),
+      right = list(list(text = "office", href = "office.html"))
+    ),
+    gallery = list(
+      navbar = list(left = list(list(text = "gallery"))),
+      meta = meta
+    )
+  )
+  expected <- config$navbar
+  expected$left <- c(
+    expected$left,
+    list(list(text = "gallery", menu = gallery_navbar_menu(meta)))
+  )
+  expect_equal(
+    navbar_with_gallery(config),
+    expected
+  )
+
+  # no gallery$navbar
+  expect_equal(
+    navbar_with_gallery(config["navbar"]),
+    config$navbar
+  )
+  # only gallery$navbar
+  expect_equal(
+    navbar_with_gallery(config["gallery"]),
+    list(left = expected$left[2])
+  )
+  # no gallery$navbar
+  expect_null(
+    navbar_with_gallery(list(dummy = "dummy"))
+  )
+})

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -141,3 +141,28 @@ test_that("Get/set round-trip does not alter metadata", {
     meta
   )
 })
+
+test_that("Metadata name field is added correctly", {
+  meta <- list(
+    a = list(foo = "A"), b = list(foo = "B"), c = list(foo = "C")
+  )
+  expected <- meta
+  expected$a$name <- "a"
+  expected$b$name <- "b"
+  expected$c$name <- "c"
+  expect_identical(
+    with_name_field(meta, "name"),
+    expected
+  )
+})
+
+test_that("Error if the name field is already present correctly", {
+  meta <- list(
+    a = list(foo = "A"), b = list(foo = "B", name = "_b_"), c = list(foo = "C")
+  )
+  expect_error(
+    with_name_field(meta, "name"),
+    glob2rx(paste("*", toQuotedString("name"), "*already in use*")),
+    ignore.case = TRUE
+  )
+})

--- a/tests/testthat/test-meta.R
+++ b/tests/testthat/test-meta.R
@@ -166,3 +166,36 @@ test_that("Error if the name field is already present correctly", {
     ignore.case = TRUE
   )
 })
+
+test_that("`order_by` configuration is parsed correctly" , {
+  expect_identical(
+    parse_order_by(c("foo", "desc(bar)", "desc(foo(bar))", "foo(desc(bar))")),
+    list(
+      field = c("foo", "bar", "foo(bar)", "foo(desc(bar))"),
+      decreasing = c(FALSE, TRUE, TRUE, FALSE)
+    )
+  )
+})
+
+test_that("Metadata are ordered correctly", {
+  meta <- list(
+    b = list(foo = "A", bar = "B", zoo = "A"), # 2
+    d = list(foo = "B", bar = "B", zoo = "B"), # 5
+    e = list(foo = "B", bar = "B", zoo = "A"), # 1
+    a = list(           bar = "B", zoo = "A"), # 3
+    c = list(foo = "B", bar = "B", zoo = "B")  # 4
+  )
+  expect_identical(
+    sort_meta(meta, by = c("zoo", "desc(foo)")),
+    meta[c("e", "b", "a", "c", "d")]
+  )
+  expect_identical(
+    sort_meta(meta),
+    meta[letters[1:5]]
+  )
+  expect_identical(
+    sort_meta(meta, "dummy"),
+    meta[letters[1:5]]
+  )
+})
+


### PR DESCRIPTION
## New features

- `include_before` and `include_after` in the `gallery` site configuration now define the path to a file with the included content (#14). The old inline content definition is still supported but triggers a deprecation warning.
- A new field `order_by` in the `gallery` site configuration allows specifying a set of fields the metadata should be ordered by (#15).
- A new metadata field `page_name` is included for each page, containing the name of the corresponding element in the metadata list eventually used for the resulting HTML page (#15).
- Icons for the gallery navigation bar menu are now supported in the metadata, and specified as a new field `menu_icon` or by defining the `menu_entry` field with two components `text` and `icon` (#16).

## Minor fix

- The `gallery_site()` generator now works with an empty list of metadata (#20).
