### PR TITLE
Release v0.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rmdgallery
 Title: R Markdown Website Gallery Generator
-Version: 0.3.1.9000
+Version: 0.4.0
 Authors@R: 
     person(given = "Riccardo",
            family = "Porreca",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rmdgallery (development version)
+
 # rmdgallery 0.3.0
 
 ## New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-# rmdgallery (development version)
+# rmdgallery 0.4.0
 
-- A function `site_path()`, constructing paths relative to the site source directory, is now made available when evaluating `{{...}}` expressions based on page-specific metadata and at rendering time.
+## New features
+
+- A function `site_path()`, constructing paths relative to the site source directory, is now available when evaluating `{{...}}` expressions based on page-specific metadata and at rendering time (#25).
 
 # rmdgallery 0.3.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rmdgallery (development version)
 
+- A function `site_path()`, constructing paths relative to the site source directory, is now made available when evaluating `{{...}}` expressions based on page-specific metadata and at rendering time.
+
 # rmdgallery 0.3.1
 
 ## Patch release

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -82,9 +82,6 @@ gallery_site <- function(input, ...) {
       output_file <- NULL
       if (!quiet) message("\nRendering: ", x)
 
-      # make utilities available when filling templates and rendering
-      envir <- render_time_env(input, parent = envir)
-
       if (tools::file_ext(x) == "meta") {
 
         name <- tools::file_path_sans_ext(x)

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -79,19 +79,21 @@ gallery_site <- function(input, ...) {
       }
 
       # log the file being rendered
-      output_file <- NULL
       if (!quiet) message("\nRendering: ", x)
 
-      if (tools::file_ext(x) == "meta") {
+      output_file <- NULL
+      knit_params <- NULL
 
+      if (tools::file_ext(x) == "meta") {
         name <- tools::file_path_sans_ext(x)
         meta <- config$gallery$meta[[name]]
         if (!quiet) message("\nMetadata from: ", meta$.meta_file)
-        # gallery config:
+        # include gallery configuration
         meta$gallery_config <- if (is.null(config$gallery)) list() else config$gallery
-        output_file <- name # extension and directory are included by rmarkdown::render
-
+        # temporary Rmd file with the filled template to be rendered
         x <- file.path(input, file_with_ext(sprintf(".tmp_%s", name), "Rmd"))
+        output_file <- name # extension and directory are included by rmarkdown::render
+        # custom template directory
         template_dir <- if (!is.null(config$gallery$template_dir)) {
           file.path(input, config$gallery$template_dir)
         }

--- a/R/gallery_site_generator.R
+++ b/R/gallery_site_generator.R
@@ -82,7 +82,11 @@ gallery_site <- function(input, ...) {
       output_file <- NULL
       if (!quiet) message("\nRendering: ", x)
 
+      # make utilities available when filling templates and rendering
+      envir <- render_time_env(input, parent = envir)
+
       if (tools::file_ext(x) == "meta") {
+
         name <- tools::file_path_sans_ext(x)
         meta <- config$gallery$meta[[name]]
         if (!quiet) message("\nMetadata from: ", meta$.meta_file)
@@ -94,14 +98,12 @@ gallery_site <- function(input, ...) {
         template_dir <- if (!is.null(config$gallery$template_dir)) {
           file.path(input, config$gallery$template_dir)
         }
-        rmd_content <- from_template(meta, template_dir)
+        rmd_content <- from_template(meta, template_dir, envir = envir)
         knit_params <- attr(rmd_content, "params")
         writeLines(rmd_content, x)
         on.exit(unlink(x))
       }
 
-      # make some useful utils available when rendering
-      envir <- list2env(render_time_utils, parent = envir)
       output <- render_one(input = x,
                            output_format = output_format,
                            output_file = output_file,

--- a/R/templates.R
+++ b/R/templates.R
@@ -70,26 +70,27 @@ gallery_content <- function(..., gallery_config = NULL, class = NULL) {
 }
 
 
-fill <- function(x, with) {
+fill <- function(x, with, envir = parent.frame()) {
   y <- glue::glue_data(
     with,
     x,
-    .open = "{{", .close = "}}"
+    .open = "{{", .close = "}}",
+    .envir = envir
   )
   class(y) <- class(x)
   y
 }
 
-fill_template <- function(meta, template) {
+fill_template <- function(meta, template, envir = parent.frame()) {
   if (length(meta$gallery_config$include_before) > 0L) {
     meta$gallery_config$include_before <-
-      fill(meta$gallery_config$include_before, meta)
+      fill(meta$gallery_config$include_before, meta, envir)
   }
   if (length(meta$gallery_config$include_after) > 0L) {
     meta$gallery_config$include_after <-
-      fill(meta$gallery_config$include_after, meta)
+      fill(meta$gallery_config$include_after, meta, envir)
   }
-  filled <- fill(paste(template, collapse = "\n"), meta)
+  filled <- fill(paste(template, collapse = "\n"), meta, envir)
   knit_params <- names(knitr::knit_params(filled, evaluate = FALSE))
   attr(filled, "params") <- meta[names(meta) %in% knit_params]
   filled
@@ -110,7 +111,7 @@ find_template <- function(template, paths = character(0)) {
   template_file
 }
 
-from_template <- function(meta, paths = character(0)) {
+from_template <- function(meta, paths = character(0), envir = parent.frame()) {
   template <- find_template(meta$template, paths)
-  fill_template(meta, readLines(template))
+  fill_template(meta, readLines(template), envir)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,15 +8,16 @@
   x
 }
 
-# define a list of utilities to be made available when rendering
-render_time_utils <- list(
+# list of utilities to be made available when filling templates / rendering
+fill_render_utils <- list(
   `%||%` = `%||%`
 )
 
-# environment with render-time utilities, including site_path()
-render_time_env <- function(input, parent = parent.frame()) {
-  env <- list2env(render_time_utils, parent = parent)
-  env$site_path <- function(...) file.path(input, ...)
+# environment with fill- / render-time utilities, including `site_path()` for
+# constructing paths relative to side_dir
+fill_render_env <- function(site_dir, parent = parent.frame()) {
+  env <- list2env(fill_render_utils, parent = parent)
+  env$site_path <- function(...) file.path(site_dir, ...)
   env
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -13,6 +13,14 @@ render_time_utils <- list(
   `%||%` = `%||%`
 )
 
+# environment with render-time utilities, including site_path()
+render_time_env <- function(input, parent = parent.frame()) {
+  env <- list2env(render_time_utils, parent = parent)
+  env$site_path <- function(...) file.path(input, ...)
+  env
+}
+
+
 toQuotedString <- function(x) {
   toString(sQuote(x, q = FALSE))
 }

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ gallery:
 
 You can see the various elements of the configuration in action in the [rmd-gallery-example](https://github.com/riccardoporreca/rmd-gallery-example#readme) GitHub repository.
 
+### Site-relative paths
+
+Paths to additional files (e.g. to `source()` utilities), needed when evaluating `{{...}}` expressions based on page-specific metadata and at rendering time,
+can be safely constructed as relative to the site source directory using function `site_path()`.
+
 ### Custom templates
 
 Besides the templates provided with **rmdgallery** (described above), it is possible to define custom R Markdown templates. These are standard R Markdown documents (as you would normally include in a [simple R Markdown website](https://bookdown.org/yihui/rmarkdown/rmarkdown-site.html)), which however will be populated with specific page metadata using two mechanisms:

--- a/tests/testthat/test-render-utils.R
+++ b/tests/testthat/test-render-utils.R
@@ -1,5 +1,5 @@
-testthat::test_that("render_time_env returns a working site_path()", {
-  env <- render_time_env("foo")
+testthat::test_that("fill_render_env returns a working site_path()", {
+  env <- fill_render_env("foo")
   expect_is(env$site_path, "function")
   expect_identical(
     env$site_path("bar", "dummy"),
@@ -7,16 +7,16 @@ testthat::test_that("render_time_env returns a working site_path()", {
   )
 })
 
-testthat::test_that("render_time_env includes all render_time_utils", {
-  env <- render_time_env("foo")
+testthat::test_that("fill_render_env includes all fill_render_utils", {
+  env <- fill_render_env("foo")
   expect_identical(
-    as.list(env)[names(render_time_utils)],
-    render_time_utils
+    as.list(env)[names(fill_render_utils)],
+    fill_render_utils
   )
 })
 
-testthat::test_that("render_time_env includes the provided parent", {
-  env <- render_time_env("foo", parent = list2env(list(bar = "bar")))
+testthat::test_that("fill_render_env includes the provided parent", {
+  env <- fill_render_env("foo", parent = list2env(list(bar = "bar")))
   expect_error(
     get("bar", envir = env, inherits = FALSE),
     "'bar' not found"

--- a/tests/testthat/test-render-utils.R
+++ b/tests/testthat/test-render-utils.R
@@ -1,0 +1,25 @@
+testthat::test_that("render_time_env returns a working site_path()", {
+  env <- render_time_env("foo")
+  expect_is(env$site_path, "function")
+  expect_identical(
+    env$site_path("bar", "dummy"),
+    file.path("foo", "bar", "dummy")
+  )
+})
+
+testthat::test_that("render_time_env includes all render_time_utils", {
+  env <- render_time_env("foo")
+  expect_identical(
+    as.list(env)[names(render_time_utils)],
+    render_time_utils
+  )
+})
+
+testthat::test_that("render_time_env includes the provided parent", {
+  env <- render_time_env("foo", parent = list2env(list(bar = "bar")))
+  expect_error(
+    get("bar", envir = env, inherits = FALSE),
+    "'bar' not found"
+  )
+  expect_identical(get("bar", envir = env), "bar")
+})


### PR DESCRIPTION
## New features

- A function `site_path()`, constructing paths relative to the site source directory, is now available when evaluating `{{...}}` expressions based on page-specific metadata and at rendering time (#25).